### PR TITLE
bios: Rename DMG_ROM.bin to dmg_boot.bin

### DIFF
--- a/controllers/mapper/gb_mapper.c
+++ b/controllers/mapper/gb_mapper.c
@@ -29,7 +29,10 @@ static bool get_mapper_number(char *path, uint8_t *number);
 static void add_mapper(struct controller_instance *i, char *p, uint8_t n);
 
 /* Command-line parameters */
-static char *bootrom_path = "DMG_ROM.bin";
+/**
+ * libretro: Have DMG_ROM.bin match the naming of the other gameboy cores (dmg_boot.bin)
+ */
+static char *bootrom_path = "dmg_boot.bin";
 PARAM(bootrom_path, string, "bootrom", "gb", "GameBoy boot ROM path")
 
 static char *mbcs[] = {


### PR DESCRIPTION
This renames the expected BIOS name from DMG_ROM.bin to dmg_boot.bin to match the other libretro Gameboy cores.

This is spawned from the conversation over at https://github.com/libretro/libretro-super/pull/547/files#r141584619