### PR TITLE
gcc 15: fix wrong prototype definition

### DIFF
--- a/include/audio.h
+++ b/include/audio.h
@@ -46,7 +46,7 @@ struct audio_frontend {
 	void (*deinit)(struct audio_frontend *fe);
 };
 
-bool audio_init();
+bool audio_init(struct audio_specs *specs);
 void audio_enqueue(void *buffer, int count);
 void audio_start();
 void audio_stop();

--- a/mach/gb.c
+++ b/mach/gb.c
@@ -79,8 +79,8 @@ struct gb_data {
 	struct region wave_region;
 };
 
-static bool gb_init();
-static void gb_deinit();
+static bool gb_init(struct machine *machine);
+static void gb_deinit(struct machine *machine);
 
 /* VRAM area */
 static struct resource vram_area =

--- a/mach/nes.c
+++ b/mach/nes.c
@@ -70,8 +70,8 @@ struct nes_data {
 	struct region wram_region;
 };
 
-static bool nes_init();
-static void nes_deinit();
+static bool nes_init(struct machine *machine);
+static void nes_deinit(struct machine *machine);
 
 /* WRAM area */
 static struct resource wram_mirror =


### PR DESCRIPTION
Fixes:

```
aarch64-webos-linux-gnu-gcc -c -o ../main/audio.o ../main/audio.c -I../include/ -Wall -fpic -fstrict-aliasing   -D__LIBRETRO__  -O3 -DNDEBUG
../main/audio.c:65:6: error: conflicting types for ‘audio_init’; have ‘_Bool(struct audio_specs *)’
   65 | bool audio_init(struct audio_specs *specs)
      |      ^~~~~~~~~~
In file included from ../main/audio.c:4:
../include/audio.h:49:6: note: previous declaration of ‘audio_init’ with type ‘_Bool(void)’
   49 | bool audio_init();
      |      ^~~~~~~~~~
make: *** [Makefile.rules:39: ../main/audio.o] Error 1
```